### PR TITLE
Fixed issue #1: in some case, TraceListener.onStopRequest is not called

### DIFF
--- a/net-log.js
+++ b/net-log.js
@@ -134,6 +134,7 @@ TracingListener.prototype = {
     },
     onDataAvailable: function(request, context, inputStream, offset, count) {
         try {
+            request = request.QueryInterface(Ci.nsIChannel);
             if (typeof(request.URI) !== "undefined" && this._inWindow(request)) {
                 this.dataLength += count;
                 let win = getWindowForRequest(request);

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "fullName": "Jetpack net-log",
     "description": "Resource loading watcher for Addon-SDK",
     "author": "Olivier Meunier <olivier@neokraft.net>",
+    "contributors": ["Laurent Jouanneau <ljouanneau@gmail.com>"],
     "version": "1.0",
     "license": "MPL 2.0",
 


### PR DESCRIPTION
In onDataAvailable, it seems that sometime, request parameter is
a nsIRequest object, not a nsIChannel object.. We should query
the nsIChannel interface to avoid errors during the call
of originalListener. Don't tell me why. At least this fix works
for me.
