### PR TITLE
Improved the support of network errors

### DIFF
--- a/net-log.js
+++ b/net-log.js
@@ -516,10 +516,6 @@ ProgressListener.prototype = {
     onLocationChange : function(progress, request, location, flags) {
 
         if (flags & Ci.nsIWebProgressListener.LOCATION_CHANGE_ERROR_PAGE) {
-            if (typeof(this.options.onLoadFinished) === "function") {
-                this.options.onLoadFinished("fail");
-            }
-            this.mainPageURI == ''
             return;
         }
 
@@ -562,7 +558,7 @@ ProgressListener.prototype = {
 
             if (this.isTransferDone(flags)) {
                 if (typeof(this.options.onContentLoaded) === "function") {
-                    this.options.onContentLoaded();
+                    this.options.onContentLoaded((request.status?false:true));
                 }
                 return;
             }
@@ -570,13 +566,7 @@ ProgressListener.prototype = {
                 this.mainPageURI = '';
                 if (typeof(this.options.onLoadFinished) === "function") {
                     let success = "success";
-                    try {
-                        if (uri != 'about:blank') {
-                            request = request.QueryInterface(Ci.nsIHttpChannel);
-                            success = (request.requestSucceeded?"success":"fail");
-                        }
-                    }
-                    catch(e){
+                    if (uri != 'about:blank' && request.status) {
                         success = 'fail';
                     }
                     this.options.onLoadFinished(success);


### PR DESCRIPTION
In case of network error (unknown domain name for example):
- loadFinished should be called only one time
- "fail" should be given only on network error, not on http error (phantomjs parity)
