### PR TITLE
Remove obsolete let

### DIFF
--- a/lib/net-log.js
+++ b/lib/net-log.js
@@ -180,7 +180,7 @@ const onRequestResponse = function(evt) {
 
     emit(listener, 'examineresponse', subject);
 
-    let listener = new TracingListener(subject, index, listener);
+    listener = new TracingListener(subject, index, listener);
     subject.QueryInterface(Ci.nsITraceableChannel);
     listener.originalListener = subject.setNewListener(listener);
 };


### PR DESCRIPTION
Firefox 35 compatibility problems:

As part of recent ES6 compliance efforts, the semantics of the `let` keyword have changed[1] in a non-backwards-compatible way which affects one or more of your add-ons. In particular:

1) Variables may no longer be declared more than once in the same scope using the `let` keyword, and may not be redeclared using the `let` keyword if they have already been declared using `var`, or as a function argument, within the same lexical scope. 

[1] https://bugzil.la/1001090
